### PR TITLE
[javalin-example] Remove unnecessary function calls

### DIFF
--- a/javalin/src/main/kotlin/info/novatec/hello/world/Application.kt
+++ b/javalin/src/main/kotlin/info/novatec/hello/world/Application.kt
@@ -7,11 +7,7 @@ import io.javalin.apibuilder.ApiBuilder.path
 fun main() {
     val app = Javalin.create().start(8080)
 
-    app.routes {
-        path("/hello") {
-            get("/") { ctx ->
-                ctx.result("Hello World!")
-            }
-        }
+    app.get("/hello") { ctx ->
+        ctx.result("Hello World!")
     }
 }


### PR DESCRIPTION
Using `routes` and `path` to declare a single lambda-handler is not idiomatic Javalin code.
Typically you only use those two functions when you start splitting out your controller code into separate classes, as shown in the documentation.